### PR TITLE
Convert each property to ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ export const useStore = create<BearState>(set => ({
 <script setup lang="ts">
   import { useStore } from './store'
 
-  const state = useStore()
+  const { bears, increase } = useStore()
 
-  // state.value.bears
-  // state.value.increase()
+  // bears.value
+  // increase.value()
 </script>
 
 <template>
-  <h1>{{ state.bears }} around here ...</h1>
-  <button @click="state.increase">one up</button>
+  <h1>{{ bears }} around here ...</h1>
+  <button @click="increase">one up</button>
 </template>
 ```
 
@@ -49,18 +49,19 @@ const bears = useStore(state => state.bears) // bears.value
 const bulls = useStore(state => state.bulls) // bulls.value
 ```
 
-Multiple state-picks
+If you want to construct a single object with multiple state-picks inside, similar to redux's mapStateToProps, you can tell zustand that you want the object to be diffed shallowly by passing the `shallow` equality function.
 
 ```ts
 import shallow from 'zustand/shallow'
 
-// Either state.bears or state.bulls change
-const state = useStore(
+// Object pick, updates either state.bears or state.bulls change
+const { bears, bulls } = useStore(
   state => ({ bears: state.bears, bulls: state.bulls }),
   shallow,
 )
 
-// state is a ref so destructuring won't work.
+// Array pick, updates either state.bears or state.bulls change
+const [bears, bulls] = useStore(state => [state.bears, state.bulls], shallow)
 ```
 
 ## Suspense

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -71,7 +71,6 @@ describe('create', () => {
           state => ({ bears: state.bears, increase: state.increase }),
           shallow,
         )
-
         return { bears, increase }
       },
       template: `

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils'
 import shallow from 'zustand/shallow'
 import { describe, expect, it } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
-import create from '..'
+import create from '../index'
 
 describe('create', () => {
   it('returns default zustand properties', () => {
@@ -23,13 +23,15 @@ describe('create', () => {
 
     const App = defineComponent({
       setup() {
-        return { state: useStore() }
+        return {
+          ...useStore(),
+        }
       },
       template: `
         <div>
-          <div data-test="bears">{{ state.bears }}</div>
-          <button data-test="inc" @click="state.increase">+</button>
-          <button data-test="dec" @click="state.decrease">-</button>
+          <div data-test="bears">{{ bears }}</div>
+          <button data-test="inc" @click="increase">+</button>
+          <button data-test="dec" @click="decrease">-</button>
         </div>
       `,
     })
@@ -62,25 +64,26 @@ describe('create', () => {
 
     const App = defineComponent({
       setup() {
-        const state = useStore(
+        const {
+          bears,
+          increase,
+        } = useStore(
           state => ({ bears: state.bears, increase: state.increase }),
           shallow,
         )
 
-        return { state }
+        return { bears, increase }
       },
       template: `
         <div>
-          <div data-test="bears">{{ state.bears }}</div>
-          <div data-test="bulls">{{ state.bulls }}</div>
-          <button data-test="inc" @click="state.increase">+</button>
+          <div data-test="bears">{{ bears }}</div>
+          <button data-test="inc" @click="increase">+</button>
         </div>
       `,
     })
 
     const wrapper = mount(App)
     expect(wrapper.get('[data-test="bears"]').text()).toBe('0')
-    expect(wrapper.get('[data-test="bulls"]').text()).toBe('')
     wrapper.get('[data-test="inc"]').trigger('click')
     await nextTick()
     expect(wrapper.get('[data-test="bears"]').text()).toBe('1')

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import type { ToRefs } from 'vue'
 import { getCurrentInstance, onUnmounted, ref, toRefs } from 'vue'
 import type {
   EqualityChecker,
@@ -10,14 +9,15 @@ import type {
   StoreApi,
 } from 'zustand/vanilla'
 import createZustandStore from 'zustand/vanilla'
-import { refToReactive } from './util'
+import type { IsPrimitive } from './util'
+import { isPrimitive, refToReactive } from './util'
 
 type UseBoundStore<
   T extends State,
   CustomStoreApi extends StoreApi<T> = StoreApi<T>,
 > = {
-  (): ToRefs<T>
-  <U>(selector: StateSelector<T, U>, equalityFn?: EqualityChecker<U>): ToRefs<U>
+  (): IsPrimitive<T>
+  <U>(selector: StateSelector<T, U>, equalityFn?: EqualityChecker<U>): IsPrimitive<U>
 } & CustomStoreApi
 
 function create<
@@ -78,7 +78,7 @@ function create<
       })
     }
 
-    return toRefs(refToReactive(state) as Record<any, any>)
+    return isPrimitive(state.value) ? state : toRefs(refToReactive(state) as Record<any, any>)
   }
 
   Object.assign(useStore, api)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { getCurrentInstance, onUnmounted, ref, toRefs } from 'vue'
+import { getCurrentInstance, onUnmounted, readonly, ref, toRefs } from 'vue'
 import type {
   EqualityChecker,
   GetState,
@@ -78,7 +78,7 @@ function create<
       })
     }
 
-    return isPrimitive(state.value) ? state : toRefs(refToReactive(state) as Record<any, any>)
+    return isPrimitive(state.value) ? readonly(state) : toRefs(refToReactive(state) as Record<any, any>)
   }
 
   Object.assign(useStore, api)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import type { Ref } from 'vue'
-import { getCurrentInstance, onUnmounted, ref } from 'vue'
+import type { ToRefs } from 'vue'
+import { getCurrentInstance, onUnmounted, ref, toRefs } from 'vue'
 import type {
   EqualityChecker,
   GetState,
@@ -10,13 +10,14 @@ import type {
   StoreApi,
 } from 'zustand/vanilla'
 import createZustandStore from 'zustand/vanilla'
+import { refToReactive } from './util'
 
 type UseBoundStore<
   T extends State,
   CustomStoreApi extends StoreApi<T> = StoreApi<T>,
 > = {
-  (): Ref<T>
-  <U>(selector: StateSelector<T, U>, equalityFn?: EqualityChecker<U>): Ref<U>
+  (): ToRefs<T>
+  <U>(selector: StateSelector<T, U>, equalityFn?: EqualityChecker<U>): ToRefs<U>
 } & CustomStoreApi
 
 function create<
@@ -77,7 +78,7 @@ function create<
       })
     }
 
-    return state
+    return toRefs(refToReactive(state) as Record<any, any>)
   }
 
   Object.assign(useStore, api)

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,13 @@
+import type { Ref } from 'vue'
+import { computed, reactive, unref } from 'vue'
+
+export function refToReactive<O, K extends keyof O>(
+  result: Ref<O>,
+): O {
+  const keys = Object.keys(unref(result))
+  return reactive(
+    Object.fromEntries(
+      keys.map(key => [key, computed(() => result.value[key as K])]),
+    ),
+  ) as O
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import type { Ref } from 'vue'
+import type { Ref, ToRefs } from 'vue'
 import { computed, reactive, unref } from 'vue'
 
 export function refToReactive<O, K extends keyof O>(
@@ -11,3 +11,14 @@ export function refToReactive<O, K extends keyof O>(
     ),
   ) as O
 }
+
+export function isPrimitive<T>(val: T): boolean {
+  if (typeof val === 'object')
+    return val === null
+
+  return typeof val !== 'function'
+}
+
+type Primitive = null | undefined | string | number | boolean | symbol | bigint
+
+export type IsPrimitive<T> = T extends Primitive ? Ref<T> : ToRefs<T>


### PR DESCRIPTION
This PR updates the returned state to an object that contains computed values or a primitive ref.

From

```vue
<script setup lang="ts">
  import { useStore } from './store'

  const state = useStore()

  // state.value.bears
  // state.value.increase()
</script>
```

To

```vue
<script setup lang="ts">
  import { useStore } from './store'

  const { bears, increase }  = useStore()
  const bulls  = useStore(state => state.bulls)

  // bears.value
  // increase.value()
 // bulls.value
</script>
```